### PR TITLE
Release v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ This example will result in logs like this when starting Valheim.
 ```
 
 # Changelog:
+- v1.2.1
+  - Fixed CopyFolder and MoveFolder moving entire 'from'-path into 'to', instead of just the indicated 'from' folder.
 - v1.2.0
   - Added folder options for move, copy, delete.
   - Fixed readme typo in filename for wild-card configs.

--- a/src/ThisGoesHere/Operations/DirectoryCopyOperation.cs
+++ b/src/ThisGoesHere/Operations/DirectoryCopyOperation.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using BepInEx;
 using Valheim.ThisGoesHere.Configs;
+using Valheim.ThisGoesHere.Utilities;
 
 namespace Valheim.ThisGoesHere.Operations;
 
@@ -37,6 +38,10 @@ internal static class DirectoryCopyOperation
 
             (string toFull, string toPartial) = PathHelper.ExtractFilePath(config.To);
 
+            var fromFolder = new DirectoryInfo(fromFull).Name;
+            toFull = Path.Combine(toFull, fromFolder);
+            toPartial = Path.Combine(toPartial, fromFolder);
+
             if (toFull == fromFull)
             {
                 return;
@@ -54,15 +59,7 @@ internal static class DirectoryCopyOperation
 
             Log.LogTrace($"Found {files.Length} files to copy.");
 
-            foreach (var fromFullFilePath in files)
-            {
-                var toRelativeFilePath = PathHelper.GetRelativePath(fromFullFilePath, toFull);
-                var toFullFilePath = Path.Combine(toFull, toRelativeFilePath);
-
-                PathHelper.EnsureDirectoryExistsForFile(toFullFilePath);
-
-                File.Copy(fromFullFilePath, toFullFilePath, true);
-            }
+            DirectoryUtils.CopyAll(new DirectoryInfo(fromFull), new DirectoryInfo(toFull));
         }
         catch (Exception e)
         {

--- a/src/ThisGoesHere/Operations/DirectoryMoveOperation.cs
+++ b/src/ThisGoesHere/Operations/DirectoryMoveOperation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Valheim.ThisGoesHere.Configs;
+using Valheim.ThisGoesHere.Utilities;
 
 namespace Valheim.ThisGoesHere.Operations;
 
@@ -36,6 +37,10 @@ internal static class DirectoryMoveOperation
 
             (string toFull, string toPartial) = PathHelper.ExtractFilePath(config.To);
 
+            var fromFolder = new DirectoryInfo(fromFull).Name;
+            toFull = Path.Combine(toFull, fromFolder);
+            toPartial = Path.Combine(toPartial, fromFolder);
+
             if (toFull == fromFull)
             {
                 return;
@@ -53,15 +58,7 @@ internal static class DirectoryMoveOperation
 
             Log.LogTrace($"Found {files.Length} files to move.");
 
-            foreach (var fromFullFilePath in files)
-            {
-                var toRelativeFilePath = PathHelper.GetRelativePath(fromFullFilePath, toFull);
-                var toFullFilePath = Path.Combine(toFull, toRelativeFilePath);
-
-                PathHelper.EnsureDirectoryExistsForFile(toFullFilePath);
-
-                File.Copy(fromFullFilePath, toFullFilePath, true);
-            }
+            DirectoryUtils.CopyAll(new DirectoryInfo(fromFull), new DirectoryInfo(toFull));
 
             Directory.Delete(fromFull, true);
         }

--- a/src/ThisGoesHere/Plugin.cs
+++ b/src/ThisGoesHere/Plugin.cs
@@ -8,7 +8,7 @@ internal class Plugin : BaseUnityPlugin
 {
     public const string Guid = ".valheim.this_goes_here";
     public const string Name = "This Goes Here";
-    public const string Version = "1.2.0";
+    public const string Version = "1.2.1";
 
     void Awake()
     {

--- a/src/ThisGoesHere/Properties/AssemblyInfo.cs
+++ b/src/ThisGoesHere/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/src/ThisGoesHere/Utilities/DirectoryUtils.cs
+++ b/src/ThisGoesHere/Utilities/DirectoryUtils.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+
+namespace Valheim.ThisGoesHere.Utilities;
+
+internal static class DirectoryUtils
+{
+    public static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+    {
+        // Copy each file into it's new directory.
+        foreach (FileInfo file in source.GetFiles())
+        {
+            var toFilePath = Path.Combine(target.FullName, file.Name);
+
+            PathHelper.EnsureDirectoryExistsForFile(toFilePath);
+
+            file.CopyTo(toFilePath, true);
+        }
+
+        // Copy each subdirectory using recursion.
+        foreach (DirectoryInfo sourceSubDir in source.GetDirectories())
+        {
+            DirectoryInfo nextTargetSubDir =
+                target.CreateSubdirectory(sourceSubDir.Name);
+            CopyAll(sourceSubDir, nextTargetSubDir);
+        }
+    }
+}

--- a/src/ThisGoesHere/Valheim.ThisGoesHere.csproj
+++ b/src/ThisGoesHere/Valheim.ThisGoesHere.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Operations\FileCopyOperation.cs" />
     <Compile Include="Operations\FileDeleteOperation.cs" />
     <Compile Include="Operations\FileMoveOperation.cs" />
+    <Compile Include="Utilities\DirectoryUtils.cs" />
     <Compile Include="Utilities\PathHelper.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/thunderstore/manifest.json
+++ b/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "This_Goes_Here",
-  "version_number": "1.2.0",
+  "version_number": "1.2.1",
   "website_url": "https://github.com/ASharpPen/Valheim.ThisGoesHere",
   "description": "Small mod for mod authors to run file operations in bepinex folders.",
   "dependencies": [


### PR DESCRIPTION
Closes #6

  - Fixed CopyFolder and MoveFolder moving entire 'from'-path into 'to', instead of just the indicated 'from' folder.